### PR TITLE
Remove additional ULID references

### DIFF
--- a/examples/rpc/requirements.txt
+++ b/examples/rpc/requirements.txt
@@ -1,4 +1,3 @@
 cbor2
 pydantic
-python-ulid
 watchdog

--- a/packages/syft-rpc/syft_rpc/protocol.py
+++ b/packages/syft-rpc/syft_rpc/protocol.py
@@ -187,7 +187,7 @@ class SyftMessage(Base):
         return validate_syftbox_url(value)
 
     def get_message_id(self) -> UUID:
-        """Generate a deterministic ULID from the message contents."""
+        """Generate a deterministic UUID from the message contents."""
         return UUID(bytes=self.__msg_hash().digest()[:16], version=4)
 
     def get_message_hash(self) -> str:
@@ -456,15 +456,15 @@ class SyftBulkFuture(Base):
 
     @property
     def id(self) -> UUID:
-        """Generate a deterministic ULID from all future IDs.
+        """Generate a deterministic UUID from all future IDs.
 
         Returns:
-            A single ULID derived from hashing all future IDs.
+            A single UUID derived from hashing all future IDs.
         """
-        # Combine all ULIDs and hash them
+        # Combine all UUIDs and hash them
         combined = ",".join(str(f.id) for f in self.futures)
         hash_bytes = hashlib.sha256(combined.encode()).digest()[:16]
-        # Use first 16 bytes of hash to create a new ULID
+        # Use first 16 bytes of hash to create a new UUID
         return UUID(bytes=hash_bytes, version=4)
 
     @property

--- a/packages/syft-rpc/syft_rpc/rpc_db.py
+++ b/packages/syft-rpc/syft_rpc/rpc_db.py
@@ -3,8 +3,7 @@ import threading
 
 from syft_core.client_shim import Client
 from typing_extensions import Optional
-from ulid import ULID
-
+from uuid import UUID
 from syft_rpc.protocol import SyftFuture
 
 __Q_CREATE_TABLE = """
@@ -61,7 +60,7 @@ def save_future(future: SyftFuture, namespace: str, client: Client = None) -> st
     return data["id"]
 
 
-def get_future(future_id: str | ULID, client: Client = None) -> Optional[SyftFuture]:
+def get_future(future_id: str | UUID, client: Client = None) -> Optional[SyftFuture]:
     client = client or DEFAULT_CLIENT
     conn = __get_connection(client)
     row = conn.execute(
@@ -74,7 +73,7 @@ def get_future(future_id: str | ULID, client: Client = None) -> Optional[SyftFut
     return SyftFuture(**dict(row))
 
 
-def delete_future(future_id: str | ULID, client: Client = None) -> None:
+def delete_future(future_id: str | UUID, client: Client = None) -> None:
     client = client or DEFAULT_CLIENT
     conn = __get_connection(client)
     conn.execute("DELETE FROM futures WHERE id = ?", (str(future_id),))


### PR DESCRIPTION
## Description
The PR removes the old ulid references, which prevents build of rpc packages


## Affected Dependencies
rpc db

## How has this been tested?
Locally

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
