### PR TITLE
Use jsDelivr to serve sdk.js code from main

### DIFF
--- a/js-sdk/examples/indexer.html
+++ b/js-sdk/examples/indexer.html
@@ -241,7 +241,10 @@
     </div>
 
     <!-- ----------- script ------------ -->
-    <script type="text/javascript" src="../src/sdk.js"></script>
+    <script
+      type="text/javascript"
+      src="https://cdn.jsdelivr.net/gh/OpenMined/syft-extras@main/js-sdk/src/sdk.js"
+    ></script>
     <script type="text/javascript">
       let syft;
       const appName = "fraggle-indexer";

--- a/js-sdk/examples/pingpong.html
+++ b/js-sdk/examples/pingpong.html
@@ -227,7 +227,10 @@
     </div>
 
     <!-- ----------- script ------------ -->
-    <script type="text/javascript" src="../src/sdk.js"></script>
+    <script
+      type="text/javascript"
+      src="https://cdn.jsdelivr.net/gh/OpenMined/syft-extras@main/js-sdk/src/sdk.js"
+    ></script>
     <script type="text/javascript">
       let syft;
       const appName = "pingpong";


### PR DESCRIPTION
Use jsDelivr (https://www.jsdelivr.com/) free CDN to serve `sdk.js` code