### PR TITLE
add kwargs + bytes to rpc.serialize

### DIFF
--- a/packages/syft-rpc/syft_rpc/rpc.py
+++ b/packages/syft-rpc/syft_rpc/rpc.py
@@ -40,20 +40,22 @@ class GenericModel(BaseModel):
         extra = "allow"
 
 
-def serialize(obj: Any) -> Optional[bytes]:
+def serialize(obj: Any, **kwargs: Any) -> Optional[bytes]:
     """Serialize an object to bytes for sending over the network."""
 
     if obj is None:
         return None
+    elif isinstance(obj, bytes):
+        return obj
     elif isinstance(obj, str):
         return obj.encode()
     elif isinstance(obj, BaseModel):
-        return obj.model_dump_json().encode()
+        return obj.model_dump_json(**kwargs).encode()
     elif is_dataclass(obj) and not isinstance(obj, type):
-        return GenericModel(**asdict(obj)).model_dump_json().encode()
+        return GenericModel(**asdict(obj)).model_dump_json(**kwargs).encode()
     else:
         # dict, list, tuple, float, int
-        return GenericModel(**obj).model_dump_json().encode()
+        return GenericModel(**obj).model_dump_json(**kwargs).encode()
 
 
 def send(


### PR DESCRIPTION
## Description

Required for sending partial updates over RPC, which needs custom kwargs in model_dump_json to work:

```
job_update = JobUpdate(uid=uuid(), status="queued")
body = rpc.serialize(job_update, exclude_unset=True)
# Same as: job_update.model_dump_json(exclude_unset=True).encode()

rpc.send(..., body=body)
```

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
