### PR TITLE
refactor: rename api_request_name to app_request_name and update rela…

### DIFF
--- a/packages/syft-core/syft_core/client_shim.py
+++ b/packages/syft-core/syft_core/client_shim.py
@@ -71,6 +71,12 @@ class Client:
         return cls(conf=SyftClientConfig.load(filepath))
 
     @property
+    def api_request_name(self) -> str:
+        """DEPRECATED. Use app_request_name instead.
+        """
+        return self.app_request_name
+
+    @property
     def app_request_name(self) -> str:
         """Returns the name of root directory of the API request calling this property.
 

--- a/packages/syft-core/syft_core/client_shim.py
+++ b/packages/syft-core/syft_core/client_shim.py
@@ -17,7 +17,7 @@ from syft_core.url import SyftBoxURL
 from syft_core.workspace import SyftWorkspace
 
 # this just makes it a bit clear what the default is for the api_data() method
-CURRENT_API_REQUEST_NAME = None
+CURRENT_APP_REQUEST_NAME = None
 MY_DATASITE = None
 
 
@@ -71,7 +71,7 @@ class Client:
         return cls(conf=SyftClientConfig.load(filepath))
 
     @property
-    def api_request_name(self) -> str:
+    def app_request_name(self) -> str:
         """Returns the name of root directory of the API request calling this property.
 
         Use this property instead of hardcoding your API request's directory name,
@@ -81,28 +81,36 @@ class Client:
         api_path = Path.cwd()
         api_name = api_path.name
         return api_name
-
+    
     def api_data(
         self,
-        api_request_name: Optional[str] = CURRENT_API_REQUEST_NAME,
+        api_request_name: Optional[str] = CURRENT_APP_REQUEST_NAME,
+        datasite: Optional[str] = MY_DATASITE,
+    ) -> Path:
+        """Deprecated method use `client.app_data` instead"""
+        return self.app_data(api_request_name, datasite)
+
+    def app_data(
+        self,
+        api_request_name: Optional[str] = CURRENT_APP_REQUEST_NAME,
         datasite: Optional[str] = MY_DATASITE,
     ) -> Path:
         """
         Gets the filesystem path to an application's API data directory for a specific datasite.
 
         Args:
-            api_request_name (Optional[str], default=CURRENT_API_REQUEST_NAME): The name of the API request
+            app_request_name (Optional[str], default=CURRENT_APP_REQUEST_NAME): The name of the API request
             whose API data path is needed.
                 If None, defaults to the name of the API request from which this method is being called.
             datasite (Optional[str], default=MY_DATASITE): The datasite's email.
                 If None, defaults to the current user's configured email.
 
         Returns:
-            Path: A filesystem path pointing to '<workspace>/datasites/<datasite>/api_data/<api_request_name>'.
+            Path: A filesystem path pointing to '<workspace>/datasites/<datasite>/api_data/<app_request_name>'.
         """
-        api_request_name = api_request_name or self.api_request_name
+        app_request_name = app_request_name or self.app_request_name
         datasite = datasite or self.config.email
-        return self.workspace.datasites / datasite / "api_data" / api_request_name
+        return self.workspace.datasites / datasite / "app_data" / app_request_name
 
     def makedirs(self, *paths: PathLike) -> None:
         """Create directories"""


### PR DESCRIPTION
### Pull Request Summary

1. **Description**:
   This pull request refactors the `client_shim.py` file within the `syft-core` package. The primary change involves renaming the variable `CURRENT_API_REQUEST_NAME` to `CURRENT_APP_REQUEST_NAME` to enhance clarity regarding its purpose. Additionally, the method `api_request_name` has been renamed to `app_request_name`, which reflects the updated naming convention. The existing method `api_data` is marked as deprecated in favor of the new `app_data` method, which is introduced to provide a clearer interface for accessing the application's API data directory.

2. **Affected Dependencies**:
   - File modified: `packages/syft-core/syft_core/client_shim.py`
   - Key components affected include:
     - The properties and methods of the `Client` class, specifically `app_request_name`, `api_data`, and `app_data`.

3. **Test Additions**:
   - No new tests have been added as part of this change. The existing functionality has been updated, but no additional test cases were included in this commit.
