### PR TITLE
Bump syft-event version to 0.2.7

### DIFF
--- a/packages/syft-event/pyproject.toml
+++ b/packages/syft-event/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syft-event"
-version = "0.2.6"
+version = "0.2.7"
 description = "A distributed event-driven RPC framework for SyftBox that enables file-based communication, request handling, and real-time file system monitoring across datasites."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/packages/syft-event/syft_event/__init__.py
+++ b/packages/syft-event/syft_event/__init__.py
@@ -2,5 +2,5 @@ from .router import EventRouter
 from .server2 import SyftEvents
 from .types import Request, Response
 
-__version__ = "0.2.6"
+__version__ = "0.2.7"
 __all__ = ["SyftEvents", "Request", "Response", "EventRouter"]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,4 @@
 version = 1
-revision = 1
 requires-python = ">=3.9"
 resolution-markers = [
     "python_full_version >= '3.10'",
@@ -67,7 +66,7 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.10' and sys_platform == 'win32'" },
+    { name = "colorama", marker = "python_full_version < '3.10' and platform_system == 'Windows'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593 }
 wheels = [
@@ -82,7 +81,7 @@ resolution-markers = [
     "python_full_version >= '3.10'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.10' and sys_platform == 'win32'" },
+    { name = "colorama", marker = "python_full_version >= '3.10' and platform_system == 'Windows'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/60/6c/8ca2efa64cf75a977a0d7fac081354553ebe483345c734fb6b6515d96bbc/click-8.2.1.tar.gz", hash = "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202", size = 286342 }
 wheels = [
@@ -585,7 +584,7 @@ requires-dist = [
 
 [[package]]
 name = "syft-event"
-version = "0.2.6"
+version = "0.2.7"
 source = { editable = "packages/syft-event" }
 dependencies = [
     { name = "loguru" },
@@ -617,14 +616,6 @@ dependencies = [
     { name = "syft-rpc" },
 ]
 
-[package.dev-dependencies]
-cli = [
-    { name = "syft-http-bridge", extra = ["cli"] },
-]
-dev = [
-    { name = "pytest" },
-]
-
 [package.metadata]
 requires-dist = [
     { name = "syft-core", editable = "packages/syft-core" },
@@ -634,10 +625,6 @@ requires-dist = [
     { name = "syft-proxy", editable = "packages/syft-proxy" },
     { name = "syft-rpc", editable = "packages/syft-rpc" },
 ]
-
-[package.metadata.requires-dev]
-cli = [{ name = "syft-http-bridge", extras = ["cli"], editable = "packages/syft-http-bridge" }]
-dev = [{ name = "pytest", specifier = ">=8.3.4" }]
 
 [[package]]
 name = "syft-high-low"
@@ -678,7 +665,6 @@ requires-dist = [
     { name = "typer", marker = "extra == 'cli'", specifier = ">=0.15.1" },
     { name = "watchdog", specifier = ">=6.0.0" },
 ]
-provides-extras = ["cli"]
 
 [[package]]
 name = "syft-proxy"
@@ -717,20 +703,12 @@ dependencies = [
     { name = "typing-extensions" },
 ]
 
-[package.dev-dependencies]
-dev = [
-    { name = "pytest" },
-]
-
 [package.metadata]
 requires-dist = [
     { name = "pydantic", specifier = ">=2.9.2" },
     { name = "syft-core", editable = "packages/syft-core" },
     { name = "typing-extensions", specifier = ">=4.12.2" },
 ]
-
-[package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = ">=8.3.4" }]
 
 [[package]]
 name = "tomli"


### PR DESCRIPTION
Update the version of syft-event to 0.2.7 and adjust dependency markers for Windows compatibility.