### PR TITLE
Make syft-core compatible with Python 3.8

### DIFF
--- a/packages/syft-core/pyproject.toml
+++ b/packages/syft-core/pyproject.toml
@@ -3,7 +3,7 @@ name = "syft-core"
 version = "0.2.8"
 description = "Add your description here"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.8"
 dependencies = [
     "pydantic[email]>=2.10.4",
     "typing-extensions>=4.12.2",

--- a/packages/syft-core/syft_core/permissions.py
+++ b/packages/syft-core/syft_core/permissions.py
@@ -9,7 +9,7 @@ import sqlite3
 import traceback
 from enum import Enum
 from pathlib import Path
-from typing import List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 import wcmatch
 import yaml
@@ -285,7 +285,7 @@ class SyftPermission(BaseModel):
     def depth(self) -> int:
         return len(self.relative_filepath.parts)
 
-    def to_dict(self) -> list[dict]:
+    def to_dict(self) -> List[dict]:
         return [x.as_file_json() for x in self.rules]
 
     @staticmethod
@@ -366,7 +366,7 @@ class SyftPermission(BaseModel):
         self,
         path: str,
         user: str,
-        permission: Union[list[str], list[PermissionType]],
+        permission: Union[List[str], List[PermissionType]],
         allow: bool = True,
     ) -> None:
         priority = len(self.rules)
@@ -421,7 +421,7 @@ class SyftPermission(BaseModel):
 
     @classmethod
     def from_rule_dicts(
-        cls, permfile_file_path: PathLike, data: Union[dict, list]
+        cls, permfile_file_path: PathLike, data: Union[Dict, List]
     ) -> "SyftPermission":
         # Handle new format with terminal flag and rules array
         if isinstance(data, list):
@@ -501,7 +501,7 @@ class ComputedPermission(BaseModel):
     user: str
     file_path: RelativePath
 
-    perms: dict[PermissionType, bool] = {
+    perms: Dict[PermissionType, bool] = {
         PermissionType.READ: False,
         PermissionType.CREATE: False,
         PermissionType.WRITE: False,

--- a/packages/syft-core/syft_core/url.py
+++ b/packages/syft-core/syft_core/url.py
@@ -1,6 +1,6 @@
 import re
 from pathlib import Path
-from typing import Any, Generator, Union
+from typing import Any, Dict, Generator, Union
 from urllib.parse import urlencode, urlparse
 
 from pydantic import GetJsonSchemaHandler, ValidationInfo
@@ -26,7 +26,7 @@ class SyftBoxURL(str):
         return bool(re.match(pattern, url))
 
     @property
-    def query(self) -> dict[str, str]:
+    def query(self) -> Dict[str, str]:
         """Returns the query parameters as a dictionary."""
         if not self.parsed.query:
             return {}
@@ -66,7 +66,7 @@ class SyftBoxURL(str):
         local_path = to_path(datasites_path) / self.host / self.path.lstrip("/")
         return local_path.resolve()
 
-    def as_http_params(self) -> dict[str, str]:
+    def as_http_params(self) -> Dict[str, str]:
         return {
             "method": "get",
             "datasite": self.host,


### PR DESCRIPTION
Hi folks, as a part of project beach I'd like to request syft-core be compatible with Python 3.8. Claude Code seems to believe this doesn't require any significant code changes. 

- Update pyproject.toml to require Python 3.8+ instead of 3.9+
- Replace Python 3.9+ type annotations (dict[...], list[...]) with typing module equivalents (Dict[...], List[...])
- Add necessary imports from typing module in permissions.py and url.py

(and i'd be grateful for a new release to PYPI with this when we get the chance)

