### PR TITLE
Decouple `syft-crypto`

### DIFF
--- a/packages/syft-event/syft_event/server2.py
+++ b/packages/syft-event/syft_event/server2.py
@@ -271,7 +271,7 @@ class SyftEvents:
             self.__register_rpc(
                 epath, func, auto_decrypt=auto_decrypt, encrypt_reply=encrypt_reply
             )
-            logger.info(
+            logger.debug(
                 f"Register RPC: {endpoint} (auto_decrypt={auto_decrypt}, encrypt_reply={encrypt_reply})"
             )
             return func


### PR DESCRIPTION
## Description
- [ ] Decouple `syft-crypto` from `syft-core` and also make it generalized enough so it can be used with [`syft-client`](https://github.com/OpenMined/syft-client/tree/main/syft_client)
- [ ] Create did documents and private keys right after the client call `client.load()` 
